### PR TITLE
Show num imported/skipped keys after slurp

### DIFF
--- a/internal/bitmapist/bitmapist.go
+++ b/internal/bitmapist/bitmapist.go
@@ -478,11 +478,12 @@ func (s *Server) handleSlurp(req red.Request) (interface{}, error) {
 	go func() {
 		s.log.Println("importing redis dataset from", addr)
 		begin := time.Now()
-		if err := s.redisImport(addr); err != nil {
+		numImported, numErr, numNonStr, numZero, err := s.redisImport(addr)
+		if err != nil {
 			s.log.Println("redis import error:", err)
 			return
 		}
-		s.log.Println("import from redis completed in", time.Since(begin))
+		s.log.Printf("Imported %d keys from redis in %q. Skipped: %d due to error, %d non-strings, %d zero-only bitmaps.", numImported, time.Since(begin), numErr, numNonStr, numZero)
 	}()
 	return resp.OK, nil
 }
@@ -1026,10 +1027,11 @@ func (s *Server) Backup(w io.Writer) error {
 	})
 }
 
-func (s *Server) redisImport(addr string) error {
+func (s *Server) redisImport(addr string) (int, int, int, int, error) {
+	var numImported, numErr, numNonStr, numZero int
 	client, err := redis.Dial("tcp", addr)
 	if err != nil {
-		return err
+		return numImported, numErr, numNonStr, numZero, err
 	}
 	defer client.Close()
 	var vals []uint32
@@ -1038,21 +1040,21 @@ func (s *Server) redisImport(addr string) error {
 	for !done {
 		a, err := client.Cmd("SCAN", cursor, "count", "10000").Array()
 		if err != nil {
-			return err
+			return numImported, numErr, numNonStr, numZero, err
 		}
 		if len(a) != 2 {
-			return fmt.Errorf("bad response array length: %d", len(a))
+			return numImported, numErr, numNonStr, numZero, fmt.Errorf("bad response array length: %d", len(a))
 		}
 		cursor, err = a[0].Str()
 		if err != nil {
-			return err
+			return numImported, numErr, numNonStr, numZero, err
 		}
 		if cursor == "0" {
 			done = true
 		}
 		keys, err := a[1].List()
 		if err != nil {
-			return err
+			return numImported, numErr, numNonStr, numZero, err
 		}
 		for _, key := range keys {
 			if key == "" {
@@ -1062,17 +1064,19 @@ func (s *Server) redisImport(addr string) error {
 			if resp.Err != nil {
 				if resp.IsType(redis.AppErr) {
 					s.log.Printf("skip load of key %q: %v", key, resp.Err)
+					numErr++
 					continue
 				}
-				return resp.Err
+				return numImported, numErr, numNonStr, numZero, resp.Err
 			}
 			if !resp.IsType(redis.BulkStr) {
 				s.log.Printf("skip load of key %q: not a string", key)
+				numNonStr++
 				continue
 			}
 			data, err := resp.Bytes()
 			if err != nil {
-				return err
+				return numImported, numErr, numNonStr, numZero, err
 			}
 			vals = vals[:0]
 			for i, b := range data {
@@ -1086,6 +1090,7 @@ func (s *Server) redisImport(addr string) error {
 				}
 			}
 			if len(vals) == 0 {
+				numZero++
 				continue
 			}
 			v := cacheItem{
@@ -1097,9 +1102,10 @@ func (s *Server) redisImport(addr string) error {
 			s.keys[key] = struct{}{}
 			s.cache[key] = v
 			s.mu.Unlock()
+			numImported++
 		}
 	}
-	return nil
+	return numImported, numErr, numNonStr, numZero, nil
 }
 
 func handleSelect(r red.Request) (interface{}, error) {


### PR DESCRIPTION
A user who runs `slurp` wants to how many keys were successfully imported. This commit prints this information when the slurp command completes.