### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.0.0'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get dependencies
       run: go mod download
     - name: Install redis
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'push'
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build image
       run: |
         echo ${GITHUB_REF##*/} | tee ci-version.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.0.0'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get dependencies
       run: go mod download
     - name: Install redis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.0.0'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get dependencies
       run: go mod download
     - name: Run tests (without redis)


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
